### PR TITLE
Add Attachment Requests 

### DIFF
--- a/liblab.config.json
+++ b/liblab.config.json
@@ -1,6 +1,6 @@
 {
   "sdkName": "signplus",
-  "apiVersion": "2.3.1",
+  "apiVersion": "2.4.0",
   "apiName": "signplus-api",
   "specFilePath": "openapi.yaml",
   "languages": ["csharp", "go", "python", "typescript", "java", "php"],
@@ -32,7 +32,7 @@
       "pypiPackageName": "signplus-python",
       "githubRepoName": "signplus-python",
       "ignoreFiles": [],
-      "sdkVersion": "1.3.0",
+      "sdkVersion": "1.4.0",
       "liblabVersion": "2",
       "additionalConstructorParameters": []
     },
@@ -40,7 +40,7 @@
       "githubRepoName": "signplus-java",
       "groupId": "com.alohi",
       "artifactId": "signplus",
-      "sdkVersion": "2.3.0",
+      "sdkVersion": "2.4.0",
       "liblabVersion": "2",
       "developers": [{
         "name": "Alohi SA",
@@ -58,7 +58,7 @@
       "npmOrg": "alohi",
       "githubRepoName": "signplus-typescript",
       "ignoreFiles": [],
-      "sdkVersion": "2.3.0",
+      "sdkVersion": "2.4.0",
       "liblabVersion": "2",
       "additionalConstructorParameters": []
     },
@@ -66,7 +66,7 @@
       "goModuleName": "github.com/alohihq/signplus-go",
       "githubRepoName": "signplus-go",
       "ignoreFiles": [],
-      "sdkVersion": "1.3.0",
+      "sdkVersion": "1.4.0",
       "liblabVersion": "2",
       "additionalConstructorParameters": []
     },
@@ -74,7 +74,7 @@
       "packageName": "alohi/signplus",
       "githubRepoName": "signplus-php",
       "ignoreFiles": [],
-      "sdkVersion": "2.3.0",
+      "sdkVersion": "2.4.0",
       "liblabVersion": "2",
       "additionalConstructorParameters": []
     },
@@ -82,7 +82,7 @@
       "packageId": "Alohi.Signplus",
       "githubRepoName": "signplus-sharp",
       "ignoreFiles": [],
-      "sdkVersion": "1.3.0",
+      "sdkVersion": "1.4.0",
       "liblabVersion": "2"
     }
   },

--- a/liblab.config.json
+++ b/liblab.config.json
@@ -1,6 +1,6 @@
 {
   "sdkName": "signplus",
-  "apiVersion": "2.4.0",
+  "apiVersion": "2.5.0",
   "apiName": "signplus-api",
   "specFilePath": "openapi.yaml",
   "languages": ["csharp", "go", "python", "typescript", "java", "php"],

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Sign.plus Developer API v2
   description: Integrate legally-binding electronic signature to your workflow
-  version: 2.4.0
+  version: 2.5.0
   contact:
     name: Sign.Plus
     url: https://sign.plus

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -343,7 +343,7 @@ paths:
                 $ref: "#/components/schemas/EnvelopeAttachments"
   "/envelope/{envelope_id}/attachments/placeholders":
     put:
-      description: Set envelope attachment placeholders
+      description: Placeholders to be set, completely replacing the existing ones.
       operationId: set_envelope_attachments_placeholders
       tags:
         - signplus
@@ -1141,7 +1141,7 @@ paths:
                 $ref: "#/components/schemas/EnvelopeAttachments"
   "/template/{template_id}/attachments/placeholders":
     put:
-      description: Set template attachment placeholders
+      description: Placeholders to be set, completely replacing the existing ones.
       operationId: set_template_attachments_placeholders
       tags:
         - signplus

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Sign.plus Developer API v2
   description: Integrate legally-binding electronic signature to your workflow
-  version: 2.3.1
+  version: 2.4.0
   contact:
     name: Sign.Plus
     url: https://sign.plus
@@ -313,6 +313,92 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Envelope"
+  "/envelope/{envelope_id}/attachments/settings":
+    put:
+      description: Set envelope attachment settings
+      operationId: set_envelope_attachments_settings
+      tags:
+        - signplus
+      security:
+        - BearerAuth:
+            - SIGN_ALL_EDIT
+      parameters:
+        - in: path
+          name: envelope_id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetEnvelopeAttachmentsSettingsRequest"
+      responses:
+        "200":
+          description: Attachment settings set successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnvelopeAttachments"
+  "/envelope/{envelope_id}/attachments/placeholders":
+    put:
+      description: Set envelope attachment placeholders
+      operationId: set_envelope_attachments_placeholders
+      tags:
+        - signplus
+      security:
+        - BearerAuth:
+            - SIGN_ALL_EDIT
+      parameters:
+        - in: path
+          name: envelope_id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetEnvelopeAttachmentsPlaceholdersRequest"
+      responses:
+        "200":
+          description: Placeholders set
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnvelopeAttachments"
+
+  "/envelope/{envelope_id}/attachments/{file_id}":
+    get:
+      description: Get envelope attachment file
+      operationId: get_attachment_file
+      tags:
+        - signplus
+      security:
+        - BearerAuth:
+            - SIGN_ALL_READ
+      parameters:
+        - in: path
+          name: envelope_id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: file_id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Attachment file retrieved successfully
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+
   "/envelope/{envelope_id}/send":
     post:
       description: Send envelope for signature
@@ -1025,6 +1111,63 @@ paths:
       responses:
         "200":
           description: Annotation deleted successfully
+  "/template/{template_id}/attachments/settings":
+    put:
+      description: Set template attachment settings
+      operationId: set_template_attachments_settings
+      tags:
+        - signplus
+      security:
+        - BearerAuth:
+            - SIGN_ALL_EDIT
+      parameters:
+        - in: path
+          name: template_id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetEnvelopeAttachmentsSettingsRequest"
+      responses:
+        "200":
+          description: Attachment settings set successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnvelopeAttachments"
+  "/template/{template_id}/attachments/placeholders":
+    put:
+      description: Set template attachment placeholders
+      operationId: set_template_attachments_placeholders
+      tags:
+        - signplus
+      security:
+        - BearerAuth:
+            - SIGN_ALL_EDIT
+      parameters:
+        - in: path
+          name: template_id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetEnvelopeAttachmentsPlaceholdersRequest"
+      responses:
+        "200":
+          description: Placeholders set
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnvelopeAttachments"
+
   /webhook:
     post:
       description: Create webhook
@@ -1139,6 +1282,76 @@ components:
             $ref: "#/components/schemas/Document"
         notification:
           $ref: "#/components/schemas/EnvelopeNotification"
+        attachments:
+          $ref: "#/components/schemas/EnvelopeAttachments"
+    EnvelopeAttachments:
+      type: object
+      properties:
+        settings:
+          $ref: "#/components/schemas/AttachmentSettings"
+        recipients:
+          type: array
+          items:
+            $ref: "#/components/schemas/AttachmentPlaceholdersPerRecipient"
+    AttachmentSettings:
+      type: object
+      properties:
+        visible_to_recipients:
+          type: boolean
+          description: Whether the attachment is visible to the recipients
+    AttachmentPlaceholdersPerRecipient:
+      type: object
+      properties:
+        recipient_id:
+          type: string
+          description: ID of the recipient
+        recipient_name:
+          type: string
+          description: Name of the recipient
+        placeholders:
+          type: array
+          items:
+            $ref: "#/components/schemas/AttachmentPlaceholder"
+    AttachmentPlaceholder:
+      type: object
+      properties:
+        recipient_id:
+          type: string
+          description: ID of the recipient
+        id:
+          type: string
+          description: ID of the attachment placeholder
+        name:
+          type: string
+          description: Name of the attachment placeholder
+        hint:
+          type: string
+          description: Hint of the attachment placeholder
+        required:
+          type: boolean
+          description: Whether the attachment placeholder is required
+        multiple:
+          type: boolean
+          description: Whether the attachment placeholder can have multiple files
+        files:
+          type: array
+          items:
+            $ref: "#/components/schemas/AttachmentPlaceholderFile"
+    AttachmentPlaceholderFile:
+      type: object
+      properties:
+        id:
+          type: string
+          description: ID of the file
+        name:
+          type: string
+          description: Name of the file
+        size:
+          type: integer
+          description: Size of the file in bytes
+        mimetype:
+          type: string
+          description: MIME type of the file
     EnvelopeLegalityLevel:
       type: string
       description: >-
@@ -1607,6 +1820,46 @@ components:
       properties:
         legality_level:
           $ref: "#/components/schemas/EnvelopeLegalityLevel"
+    SetEnvelopeAttachmentsPlaceholdersRequest:
+      type: object
+      properties:
+        placeholders:
+          type: array
+          items:
+            $ref: "#/components/schemas/AttachmentPlaceholderRequest"
+      required:
+        - placeholders
+    SetEnvelopeAttachmentsSettingsRequest:
+      type: object
+      properties:
+        settings:
+          $ref: "#/components/schemas/AttachmentSettings"
+      required:
+        - settings
+    AttachmentPlaceholderRequest:
+      type: object
+      properties:
+        recipient_id:
+          type: string
+          description: ID of the recipient
+        id:
+          type: string
+          description: ID of the attachment placeholder
+        name:
+          type: string
+        hint:
+          type: string
+          description: Hint of the attachment placeholder
+        required:
+          type: boolean
+          description: Whether the attachment placeholder is required
+        multiple:
+          type: boolean
+      required:
+        - recipient_id
+        - name
+        - required
+        - multiple
     RenameEnvelopeRequest:
       type: object
       properties:
@@ -1744,6 +1997,8 @@ components:
           description: List of dynamic fields
           items:
             type: string
+        attachments:
+          $ref: "#/components/schemas/EnvelopeAttachments"
     TemplateSigningStep:
       type: object
       properties:


### PR DESCRIPTION
Introduced Attachment Requests

Added endpoints for setting up Attachment Requests from signers. These are available on both Templates and Envelopes.
After signing, it's possible to download the uploaded files.